### PR TITLE
Boot effects

### DIFF
--- a/paramed.ado
+++ b/paramed.ado
@@ -1,6 +1,12 @@
 *!TITLE: PARAMED - causal mediation analysis using parametric regression models	
 *!AUTHORS: Hanhua Liu and Richard Emsley, Centre for Biostatistics, The University of Manchester
 *!
+*!	verson 1.5.1 GF/RAE 22/11/2019
+*!		Changed the matrix returned in e(effects) from the non-bootstrapped results to the results from the bootsrap when bootsrap is specified.
+*!
+*!
+*!
+*!
 *!	verson 1.5 HL/RAE 24 April 2013
 *!		bug fix - stata's standard calculation of p and confidence interval based on e(b) and e(V)
 *!				  (e.g. at 95%, [b-1.96*se, b+1.96*se]) does not work for non-linear cases

--- a/paramed.ado
+++ b/paramed.ado
@@ -124,6 +124,12 @@ program define paramed, eclass
 		display		
 
 		estat bootstrap, noheader	//only report bias-corrected confidence interval
+        
+        tempname boot_effects
+		mat `boot_effects' = (e(b) \ e(bias) \ e(se) \ e(ci_bc))'
+		mat coln `boot_effects' = "Estimate" "Bias" "Boot_Std_Err" "UL" "LL" 
+		*mat list `boot_effects'
+		mat effects = `boot_effects'
 	}
 
 


### PR DESCRIPTION
This branch edits the matrix saved in e(effects) when the bootstrap option is specified.
Original: Saves non-bootstrap results
Revised: Saves bootstrap results

I've implemented this feature separately to others as it changes the numerical results used for testing the bootstrap output which effects testing.